### PR TITLE
Change jQuery include URL to use google hosted CDN

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
 <html>
   <head>
     <meta charset='utf-8' />
-    <script src="http://code.jquery.com/jquery-1.8.2.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
     <script src="https://apis.google.com/js/client.js"></script>
     <script type="text/javascript">
     /**


### PR DESCRIPTION
Since the API script is coming from Google, it would be nice to keep all externally hosted scripts consistent and only dependent on Google.
