### PR TITLE
Renames Project ID to Project Number

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,7 @@
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.8.3/jquery.min.js"></script>
     <script src="https://apis.google.com/js/client.js"></script>
     <script type="text/javascript">
+
     /**
      * The number of your Google Cloud Storage Project.
      */


### PR DESCRIPTION
When an alphanumeric project ID is used in the example HTML file, the API responds with a code of 400 and a message saying: Invalid unsigned long value: 'example.com:the-project-id'. When this alphanumeric ID is instead swapped with the project's number, the requests succeed. 

This change modifies the index.html file to make it clearer that it's the project name, not the project ID which is required. 
